### PR TITLE
feat: add Unsplash image fallback for posts without coverImage

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "fetch-unsplash": "node scripts/fetch-unsplash.mjs"
   },
   "dependencies": {
     "@tailwindcss/postcss": "^4.1.18",

--- a/scripts/fetch-unsplash.mjs
+++ b/scripts/fetch-unsplash.mjs
@@ -1,0 +1,71 @@
+/**
+ * Unsplash画像事前取得スクリプト
+ * 使い方: npm run fetch-unsplash
+ *
+ * .env.local に UNSPLASH_ACCESS_KEY を設定してから実行してください。
+ * 取得した画像URLは src/data/unsplash-images.json に保存されます。
+ */
+
+import { readFileSync, writeFileSync, mkdirSync } from "fs";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(__dirname, "..");
+
+// .env.local を読み込む
+try {
+  const envFile = readFileSync(join(ROOT, ".env.local"), "utf-8");
+  for (const line of envFile.split("\n")) {
+    const match = line.match(/^([^#][^=]*)=(.*)/);
+    if (match) {
+      process.env[match[1].trim()] = match[2].trim().replace(/^["']|["']$/g, "");
+    }
+  }
+} catch {
+  // .env.local がなければ process.env をそのまま使用
+}
+
+const ACCESS_KEY = process.env.UNSPLASH_ACCESS_KEY;
+if (!ACCESS_KEY) {
+  console.error("Error: UNSPLASH_ACCESS_KEY が設定されていません。");
+  console.error(".env.local に UNSPLASH_ACCESS_KEY=<your_access_key> を追記してください。");
+  process.exit(1);
+}
+
+const APP_NAME = "blog";
+const QUERY = "technology programming";
+const COUNT = 30;
+
+console.log(`Unsplash から ${COUNT} 枚の画像を取得中...`);
+
+const response = await fetch(
+  `https://api.unsplash.com/photos/random?count=${COUNT}&query=${encodeURIComponent(QUERY)}&orientation=landscape`,
+  {
+    headers: {
+      Authorization: `Client-ID ${ACCESS_KEY}`,
+    },
+  }
+);
+
+if (!response.ok) {
+  const text = await response.text();
+  console.error(`Unsplash API エラー: ${response.status} ${response.statusText}`);
+  console.error(text);
+  process.exit(1);
+}
+
+const photos = await response.json();
+
+const images = photos.map((photo) => ({
+  url: photo.urls.regular,
+  photographer: photo.user.name,
+  photographerUrl: `${photo.user.links.html}?utm_source=${APP_NAME}&utm_medium=referral`,
+  unsplashUrl: `${photo.links.html}?utm_source=${APP_NAME}&utm_medium=referral`,
+}));
+
+const outPath = join(ROOT, "src", "data", "unsplash-images.json");
+mkdirSync(join(ROOT, "src", "data"), { recursive: true });
+writeFileSync(outPath, JSON.stringify(images, null, 2) + "\n");
+
+console.log(`✓ ${images.length} 枚の画像を src/data/unsplash-images.json に保存しました`);

--- a/src/components/articles/ArticleCard.tsx
+++ b/src/components/articles/ArticleCard.tsx
@@ -1,18 +1,28 @@
 import Link from "next/link";
 import Image from "next/image";
 import type { Post } from "@/types/post";
+import { getUnsplashImageForSlug } from "@/lib/unsplash";
 
 interface ArticleCardProps {
   post: Post;
 }
 
 export function ArticleCard({ post }: ArticleCardProps) {
+  const unsplashImage = !post.coverImage ? getUnsplashImageForSlug(post.slug) : null;
+
   return (
     <article className="group overflow-hidden rounded-xl border border-gray-200 bg-white transition-all duration-300 hover:-translate-y-1 hover:shadow-lg dark:border-gray-800 dark:bg-gray-900">
       <Link href={`/posts/${post.slug}`} className="block">
         {post.coverImage ? (
           <div className="relative aspect-video w-full overflow-hidden">
             <Image src={post.coverImage} alt={post.title} fill className="object-cover transition-transform duration-500 group-hover:scale-105" />
+          </div>
+        ) : unsplashImage ? (
+          <div className="relative aspect-video w-full overflow-hidden">
+            <Image src={unsplashImage.url} alt={post.title} fill className="object-cover transition-transform duration-500 group-hover:scale-105" />
+            <span className="absolute bottom-1 right-1 text-[10px] text-white/60 drop-shadow">
+              {unsplashImage.photographer} / Unsplash
+            </span>
           </div>
         ) : (
           <div className="flex h-32 items-center justify-center bg-gradient-to-br from-gray-50 to-gray-100 text-4xl dark:from-gray-800 dark:to-gray-900">{post.emoji}</div>

--- a/src/components/articles/ArticleDetail.tsx
+++ b/src/components/articles/ArticleDetail.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import Image from "next/image";
 import { CodeBlock } from "@/components/ui/CodeBlock";
 import type { Post } from "@/types/post";
+import { getUnsplashImageForSlug } from "@/lib/unsplash";
 
 interface ArticleDetailProps {
   post: Post;
@@ -11,15 +12,30 @@ interface ArticleDetailProps {
 }
 
 export function ArticleDetail({ post, htmlContent }: ArticleDetailProps) {
+  const unsplashImage = !post.coverImage ? getUnsplashImageForSlug(post.slug) : null;
+  const imageSrc = post.coverImage ?? unsplashImage?.url;
+
   return (
     <article className="animate-fade-in-up">
-      {post.coverImage && (
+      {imageSrc && (
         <div className="relative -mx-4 mb-8 aspect-[21/9] overflow-hidden rounded-2xl sm:mx-0">
-          <Image src={post.coverImage} alt={post.title} fill className="object-cover" priority />
+          <Image src={imageSrc} alt={post.title} fill className="object-cover" priority />
+          {unsplashImage && (
+            <p className="absolute bottom-2 right-2 text-[11px] text-white/70 drop-shadow">
+              Photo by{" "}
+              <a href={unsplashImage.photographerUrl} target="_blank" rel="noopener noreferrer" className="underline hover:text-white">
+                {unsplashImage.photographer}
+              </a>{" "}
+              on{" "}
+              <a href={unsplashImage.unsplashUrl} target="_blank" rel="noopener noreferrer" className="underline hover:text-white">
+                Unsplash
+              </a>
+            </p>
+          )}
         </div>
       )}
       <header className="mb-8">
-        {!post.coverImage && <div className="mb-4 text-4xl">{post.emoji}</div>}
+        {!imageSrc && <div className="mb-4 text-4xl">{post.emoji}</div>}
         <h1 className="mb-4 text-3xl font-bold text-gray-900 dark:text-white">{post.title}</h1>
         <div className="flex flex-wrap items-center gap-3 text-sm text-gray-500 dark:text-gray-400">
           <Link href={`/categories/${post.category}`} className="rounded-full bg-primary-50 px-3 py-0.5 text-xs font-medium text-primary-700 transition-colors hover:bg-primary-100 dark:bg-primary-900/30 dark:text-primary-300 dark:hover:bg-primary-900/50">

--- a/src/components/articles/HeroSection.tsx
+++ b/src/components/articles/HeroSection.tsx
@@ -1,22 +1,26 @@
 import Link from "next/link";
 import Image from "next/image";
 import type { Post } from "@/types/post";
+import { getUnsplashImageForSlug } from "@/lib/unsplash";
 
 interface HeroSectionProps {
   post: Post;
 }
 
 export function HeroSection({ post }: HeroSectionProps) {
+  const unsplashImage = !post.coverImage ? getUnsplashImageForSlug(post.slug) : null;
+  const imageSrc = post.coverImage ?? unsplashImage?.url;
+
   return (
     <section className="mb-10 animate-fade-in-up">
       <Link
         href={`/posts/${post.slug}`}
         className="group block overflow-hidden rounded-2xl border border-gray-200 bg-white transition-all hover:shadow-lg dark:border-gray-800 dark:bg-gray-900"
       >
-        {post.coverImage ? (
+        {imageSrc ? (
           <div className="relative aspect-[21/9] w-full overflow-hidden">
             <Image
-              src={post.coverImage}
+              src={imageSrc}
               alt={post.title}
               fill
               className="object-cover transition-transform duration-500 group-hover:scale-105"
@@ -32,9 +36,16 @@ export function HeroSection({ post }: HeroSectionProps) {
               {post.description && (
                 <p className="mb-3 line-clamp-2 text-sm text-gray-200 md:text-base">{post.description}</p>
               )}
-              <div className="flex items-center gap-3 text-sm text-gray-300">
-                <time dateTime={post.date}>{post.date}</time>
-                <span>{post.readingTime}分で読めます</span>
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-3 text-sm text-gray-300">
+                  <time dateTime={post.date}>{post.date}</time>
+                  <span>{post.readingTime}分で読めます</span>
+                </div>
+                {unsplashImage && (
+                  <span className="text-[10px] text-white/50 drop-shadow">
+                    {unsplashImage.photographer} / Unsplash
+                  </span>
+                )}
               </div>
             </div>
           </div>

--- a/src/data/unsplash-images.json
+++ b/src/data/unsplash-images.json
@@ -1,0 +1,182 @@
+[
+  {
+    "url": "https://images.unsplash.com/photo-1514070706115-47c142769603?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzk4OTl8MHwxfHJhbmRvbXx8fHx8fHx8fDE3NzE2NDIxMTB8&ixlib=rb-4.1.0&q=80&w=1080",
+    "photographer": "Ilija Boshkov",
+    "photographerUrl": "https://unsplash.com/@boshkov?utm_source=blog&utm_medium=referral",
+    "unsplashUrl": "https://unsplash.com/photos/a-computer-screen-with-a-program-running-on-it-0nI1DczRQAM?utm_source=blog&utm_medium=referral"
+  },
+  {
+    "url": "https://images.unsplash.com/photo-1534972195531-d756b9bfa9f2?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzk4OTl8MHwxfHJhbmRvbXx8fHx8fHx8fDE3NzE2NDIxMTB8&ixlib=rb-4.1.0&q=80&w=1080",
+    "photographer": "Fotis Fotopoulos",
+    "photographerUrl": "https://unsplash.com/@ffstop?utm_source=blog&utm_medium=referral",
+    "unsplashUrl": "https://unsplash.com/photos/two-black-flat-screen-computer-monitors-LJ9KY8pIH3E?utm_source=blog&utm_medium=referral"
+  },
+  {
+    "url": "https://images.unsplash.com/photo-1544847558-3ccacb31ee7f?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzk4OTl8MHwxfHJhbmRvbXx8fHx8fHx8fDE3NzE2NDIxMTB8&ixlib=rb-4.1.0&q=80&w=1080",
+    "photographer": "Sean Lim",
+    "photographerUrl": "https://unsplash.com/@seanlimm?utm_source=blog&utm_medium=referral",
+    "unsplashUrl": "https://unsplash.com/photos/black-laptop-computer-displaying-blue-screen-NPlv2pkYoUA?utm_source=blog&utm_medium=referral"
+  },
+  {
+    "url": "https://images.unsplash.com/photo-1584949091708-0a21d38ab8de?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzk4OTl8MHwxfHJhbmRvbXx8fHx8fHx8fDE3NzE2NDIxMTB8&ixlib=rb-4.1.0&q=80&w=1080",
+    "photographer": "Mitchell Luo",
+    "photographerUrl": "https://unsplash.com/@mitchel3uo?utm_source=blog&utm_medium=referral",
+    "unsplashUrl": "https://unsplash.com/photos/red-blue-and-green-textile-KM9rx_KSmWk?utm_source=blog&utm_medium=referral"
+  },
+  {
+    "url": "https://images.unsplash.com/photo-1600080404522-0d188a6a7971?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzk4OTl8MHwxfHJhbmRvbXx8fHx8fHx8fDE3NzE2NDIxMTB8&ixlib=rb-4.1.0&q=80&w=1080",
+    "photographer": "Kumpan Electric",
+    "photographerUrl": "https://unsplash.com/@kumpan_electric?utm_source=blog&utm_medium=referral",
+    "unsplashUrl": "https://unsplash.com/photos/blue-and-green-digital-device-2PtUIVqbRLE?utm_source=blog&utm_medium=referral"
+  },
+  {
+    "url": "https://images.unsplash.com/photo-1604591259403-81d6c9cf87d7?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzk4OTl8MHwxfHJhbmRvbXx8fHx8fHx8fDE3NzE2NDIxMTB8&ixlib=rb-4.1.0&q=80&w=1080",
+    "photographer": "Artur Shamsutdinov",
+    "photographerUrl": "https://unsplash.com/@roketpik?utm_source=blog&utm_medium=referral",
+    "unsplashUrl": "https://unsplash.com/photos/text-7MJpHQdGXGA?utm_source=blog&utm_medium=referral"
+  },
+  {
+    "url": "https://images.unsplash.com/photo-1617529520608-42a0fe601be2?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzk4OTl8MHwxfHJhbmRvbXx8fHx8fHx8fDE3NzE2NDIxMTB8&ixlib=rb-4.1.0&q=80&w=1080",
+    "photographer": "Jexo",
+    "photographerUrl": "https://unsplash.com/@jexo?utm_source=blog&utm_medium=referral",
+    "unsplashUrl": "https://unsplash.com/photos/purple-flowers-in-white-ceramic-vase-beside-black-laptop-computer-5OgJB9CVb68?utm_source=blog&utm_medium=referral"
+  },
+  {
+    "url": "https://images.unsplash.com/photo-1632910121591-29e2484c0259?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzk4OTl8MHwxfHJhbmRvbXx8fHx8fHx8fDE3NzE2NDIxMTB8&ixlib=rb-4.1.0&q=80&w=1080",
+    "photographer": "Shamin Haky",
+    "photographerUrl": "https://unsplash.com/@haky?utm_source=blog&utm_medium=referral",
+    "unsplashUrl": "https://unsplash.com/photos/two-men-working-on-computers-in-an-office-RIk-i9rXPao?utm_source=blog&utm_medium=referral"
+  },
+  {
+    "url": "https://images.unsplash.com/photo-1632910061325-10116ac047e3?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzk4OTl8MHwxfHJhbmRvbXx8fHx8fHx8fDE3NzE2NDIxMTB8&ixlib=rb-4.1.0&q=80&w=1080",
+    "photographer": "Shamin Haky",
+    "photographerUrl": "https://unsplash.com/@haky?utm_source=blog&utm_medium=referral",
+    "unsplashUrl": "https://unsplash.com/photos/a-man-sitting-at-a-table-using-a-laptop-computer-gR3NvNg3GX4?utm_source=blog&utm_medium=referral"
+  },
+  {
+    "url": "https://images.unsplash.com/photo-1632910088125-e85bec44bb0e?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzk4OTl8MHwxfHJhbmRvbXx8fHx8fHx8fDE3NzE2NDIxMTB8&ixlib=rb-4.1.0&q=80&w=1080",
+    "photographer": "Shamin Haky",
+    "photographerUrl": "https://unsplash.com/@haky?utm_source=blog&utm_medium=referral",
+    "unsplashUrl": "https://unsplash.com/photos/a-person-using-a-laptop-on-a-wooden-table-EuOazV2Zem0?utm_source=blog&utm_medium=referral"
+  },
+  {
+    "url": "https://images.unsplash.com/photo-1668713701571-1d1cbcefe7bd?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzk4OTl8MHwxfHJhbmRvbXx8fHx8fHx8fDE3NzE2NDIxMTB8&ixlib=rb-4.1.0&q=80&w=1080",
+    "photographer": "Ionela Mat",
+    "photographerUrl": "https://unsplash.com/@ionelaaaaa?utm_source=blog&utm_medium=referral",
+    "unsplashUrl": "https://unsplash.com/photos/a-notebook-and-a-pen-on-a-desk-tEzkUEOSnqs?utm_source=blog&utm_medium=referral"
+  },
+  {
+    "url": "https://images.unsplash.com/photo-1703969083653-da62f9ea70af?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzk4OTl8MHwxfHJhbmRvbXx8fHx8fHx8fDE3NzE2NDIxMTB8&ixlib=rb-4.1.0&q=80&w=1080",
+    "photographer": "Roi Solomon",
+    "photographerUrl": "https://unsplash.com/@roisolomon?utm_source=blog&utm_medium=referral",
+    "unsplashUrl": "https://unsplash.com/photos/a-computer-monitor-sitting-on-top-of-a-desk-5cDKkhsK8ec?utm_source=blog&utm_medium=referral"
+  },
+  {
+    "url": "https://images.unsplash.com/photo-1738255654134-1877cb984a8f?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzk4OTl8MHwxfHJhbmRvbXx8fHx8fHx8fDE3NzE2NDIxMTB8&ixlib=rb-4.1.0&q=80&w=1080",
+    "photographer": "Jiří Navrátil",
+    "photographerUrl": "https://unsplash.com/@stillwell_?utm_source=blog&utm_medium=referral",
+    "unsplashUrl": "https://unsplash.com/photos/a-computer-screen-with-a-bunch-of-code-on-it-YxSKnaiYpig?utm_source=blog&utm_medium=referral"
+  },
+  {
+    "url": "https://images.unsplash.com/photo-1753998943918-dd2dfc4ee6ed?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzk4OTl8MHwxfHJhbmRvbXx8fHx8fHx8fDE3NzE2NDIxMTB8&ixlib=rb-4.1.0&q=80&w=1080",
+    "photographer": "Rob Wingate",
+    "photographerUrl": "https://unsplash.com/@robwingate?utm_source=blog&utm_medium=referral",
+    "unsplashUrl": "https://unsplash.com/photos/code-is-displayed-on-a-computer-monitor-zUrEj_OwLQM?utm_source=blog&utm_medium=referral"
+  },
+  {
+    "url": "https://images.unsplash.com/photo-1757165792338-b4e8a88ae1c7?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzk4OTl8MHwxfHJhbmRvbXx8fHx8fHx8fDE3NzE2NDIxMTB8&ixlib=rb-4.1.0&q=80&w=1080",
+    "photographer": "Andrey Matveev",
+    "photographerUrl": "https://unsplash.com/@zelebb?utm_source=blog&utm_medium=referral",
+    "unsplashUrl": "https://unsplash.com/photos/hand-holding-smartphone-displaying-lines-of-code-CmodNbBxFXc?utm_source=blog&utm_medium=referral"
+  },
+  {
+    "url": "https://images.unsplash.com/photo-1759139681761-852dd24340df?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzk4OTl8MHwxfHJhbmRvbXx8fHx8fHx8fDE3NzE2NDIxMTB8&ixlib=rb-4.1.0&q=80&w=1080",
+    "photographer": "Rahul Mishra",
+    "photographerUrl": "https://unsplash.com/@rahuulmiishra?utm_source=blog&utm_medium=referral",
+    "unsplashUrl": "https://unsplash.com/photos/laptop-phone-keyboard-headphones-and-puzzle-cube-on-desk-YztI1NpmqHg?utm_source=blog&utm_medium=referral"
+  },
+  {
+    "url": "https://images.unsplash.com/photo-1759752393978-92d3ccf09380?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzk4OTl8MHwxfHJhbmRvbXx8fHx8fHx8fDE3NzE2NDIxMTB8&ixlib=rb-4.1.0&q=80&w=1080",
+    "photographer": "Bluestonex",
+    "photographerUrl": "https://unsplash.com/@bluestonex_apphaus?utm_source=blog&utm_medium=referral",
+    "unsplashUrl": "https://unsplash.com/photos/woman-typing-code-on-a-laptop-computer-q4xnrxKGSq0?utm_source=blog&utm_medium=referral"
+  },
+  {
+    "url": "https://images.unsplash.com/photo-1759884247447-beea12f8a207?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzk4OTl8MHwxfHJhbmRvbXx8fHx8fHx8fDE3NzE2NDIxMTB8&ixlib=rb-4.1.0&q=80&w=1080",
+    "photographer": "Sigmund",
+    "photographerUrl": "https://unsplash.com/@sigmund?utm_source=blog&utm_medium=referral",
+    "unsplashUrl": "https://unsplash.com/photos/woman-with-glasses-coding-on-a-laptop-computer-YZ_V9z8NEqY?utm_source=blog&utm_medium=referral"
+  },
+  {
+    "url": "https://images.unsplash.com/photo-1760548425425-e42e77fa38f1?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzk4OTl8MHwxfHJhbmRvbXx8fHx8fHx8fDE3NzE2NDIxMTB8&ixlib=rb-4.1.0&q=80&w=1080",
+    "photographer": "Jakub Żerdzicki",
+    "photographerUrl": "https://unsplash.com/@jakubzerdzicki?utm_source=blog&utm_medium=referral",
+    "unsplashUrl": "https://unsplash.com/photos/computer-screen-displaying-colorful-code-snippets-2DkNX2wVVY4?utm_source=blog&utm_medium=referral"
+  },
+  {
+    "url": "https://images.unsplash.com/photo-1763568258844-b31a923568b8?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzk4OTl8MHwxfHJhbmRvbXx8fHx8fHx8fDE3NzE2NDIxMTB8&ixlib=rb-4.1.0&q=80&w=1080",
+    "photographer": "Daniil Komov",
+    "photographerUrl": "https://unsplash.com/@dkomow?utm_source=blog&utm_medium=referral",
+    "unsplashUrl": "https://unsplash.com/photos/laptop-displaying-code-with-a-small-plush-toy-4isRrYI8GwI?utm_source=blog&utm_medium=referral"
+  },
+  {
+    "url": "https://images.unsplash.com/photo-1763568258143-497992aa73da?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzk4OTl8MHwxfHJhbmRvbXx8fHx8fHx8fDE3NzE2NDIxMTB8&ixlib=rb-4.1.0&q=80&w=1080",
+    "photographer": "Daniil Komov",
+    "photographerUrl": "https://unsplash.com/@dkomow?utm_source=blog&utm_medium=referral",
+    "unsplashUrl": "https://unsplash.com/photos/laptop-screen-displaying-code-with-coffee-mug-nwfWXz-JSWA?utm_source=blog&utm_medium=referral"
+  },
+  {
+    "url": "https://images.unsplash.com/photo-1763568258299-0bac211f204e?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzk4OTl8MHwxfHJhbmRvbXx8fHx8fHx8fDE3NzE2NDIxMTB8&ixlib=rb-4.1.0&q=80&w=1080",
+    "photographer": "Daniil Komov",
+    "photographerUrl": "https://unsplash.com/@dkomow?utm_source=blog&utm_medium=referral",
+    "unsplashUrl": "https://unsplash.com/photos/laptop-screen-displaying-code-next-to-coffee-mug-tiFQ5RxQdT8?utm_source=blog&utm_medium=referral"
+  },
+  {
+    "url": "https://images.unsplash.com/photo-1763568258612-0ae7f6eb1422?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzk4OTl8MHwxfHJhbmRvbXx8fHx8fHx8fDE3NzE2NDIxMTB8&ixlib=rb-4.1.0&q=80&w=1080",
+    "photographer": "Daniil Komov",
+    "photographerUrl": "https://unsplash.com/@dkomow?utm_source=blog&utm_medium=referral",
+    "unsplashUrl": "https://unsplash.com/photos/laptop-with-code-and-a-small-plush-octopus-PlvRMqKVkRc?utm_source=blog&utm_medium=referral"
+  },
+  {
+    "url": "https://images.unsplash.com/photo-1763568258492-9569a0af2127?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzk4OTl8MHwxfHJhbmRvbXx8fHx8fHx8fDE3NzE2NDIxMTB8&ixlib=rb-4.1.0&q=80&w=1080",
+    "photographer": "Daniil Komov",
+    "photographerUrl": "https://unsplash.com/@dkomow?utm_source=blog&utm_medium=referral",
+    "unsplashUrl": "https://unsplash.com/photos/laptop-screen-displaying-code-with-colorful-background-xHS2Gbjw4OI?utm_source=blog&utm_medium=referral"
+  },
+  {
+    "url": "https://images.unsplash.com/photo-1763568258439-de52f4b4e7f9?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzk4OTl8MHwxfHJhbmRvbXx8fHx8fHx8fDE3NzE2NDIxMTB8&ixlib=rb-4.1.0&q=80&w=1080",
+    "photographer": "Daniil Komov",
+    "photographerUrl": "https://unsplash.com/@dkomow?utm_source=blog&utm_medium=referral",
+    "unsplashUrl": "https://unsplash.com/photos/computer-screen-displaying-code-with-a-toy-reflected-jXyaodR8dWk?utm_source=blog&utm_medium=referral"
+  },
+  {
+    "url": "https://images.unsplash.com/photo-1763568258474-7c2330c1a893?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzk4OTl8MHwxfHJhbmRvbXx8fHx8fHx8fDE3NzE2NDIxMTB8&ixlib=rb-4.1.0&q=80&w=1080",
+    "photographer": "Daniil Komov",
+    "photographerUrl": "https://unsplash.com/@dkomow?utm_source=blog&utm_medium=referral",
+    "unsplashUrl": "https://unsplash.com/photos/laptop-with-code-phone-glasses-and-plush-toy-rJkC2VsjKjQ?utm_source=blog&utm_medium=referral"
+  },
+  {
+    "url": "https://images.unsplash.com/photo-1763568258235-f40425a94af9?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzk4OTl8MHwxfHJhbmRvbXx8fHx8fHx8fDE3NzE2NDIxMTB8&ixlib=rb-4.1.0&q=80&w=1080",
+    "photographer": "Daniil Komov",
+    "photographerUrl": "https://unsplash.com/@dkomow?utm_source=blog&utm_medium=referral",
+    "unsplashUrl": "https://unsplash.com/photos/computer-screen-displaying-code-with-a-context-menu-bglsBQQwMWA?utm_source=blog&utm_medium=referral"
+  },
+  {
+    "url": "https://images.unsplash.com/photo-1763568258239-d3b5c95019af?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzk4OTl8MHwxfHJhbmRvbXx8fHx8fHx8fDE3NzE2NDIxMTB8&ixlib=rb-4.1.0&q=80&w=1080",
+    "photographer": "Daniil Komov",
+    "photographerUrl": "https://unsplash.com/@dkomow?utm_source=blog&utm_medium=referral",
+    "unsplashUrl": "https://unsplash.com/photos/person-typing-on-a-laptop-with-code-displayed-43d76nNY2YU?utm_source=blog&utm_medium=referral"
+  },
+  {
+    "url": "https://images.unsplash.com/photo-1763568258388-25a20ddd8a95?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzk4OTl8MHwxfHJhbmRvbXx8fHx8fHx8fDE3NzE2NDIxMTB8&ixlib=rb-4.1.0&q=80&w=1080",
+    "photographer": "Daniil Komov",
+    "photographerUrl": "https://unsplash.com/@dkomow?utm_source=blog&utm_medium=referral",
+    "unsplashUrl": "https://unsplash.com/photos/laptop-screen-displaying-code-with-a-small-octopus-toy-SbRnEcFKMn4?utm_source=blog&utm_medium=referral"
+  },
+  {
+    "url": "https://images.unsplash.com/photo-1771444700452-f9bc772c6f6c?crop=entropy&cs=tinysrgb&fit=max&fm=jpg&ixid=M3w3Nzk4OTl8MHwxfHJhbmRvbXx8fHx8fHx8fDE3NzE2NDIxMTB8&ixlib=rb-4.1.0&q=80&w=1080",
+    "photographer": "Faz Islam",
+    "photographerUrl": "https://unsplash.com/@faz_islam?utm_source=blog&utm_medium=referral",
+    "unsplashUrl": "https://unsplash.com/photos/close-up-of-a-black-keyboard-with-blue-backlighting-kZBX1tsEO4E?utm_source=blog&utm_medium=referral"
+  }
+]

--- a/src/lib/unsplash.ts
+++ b/src/lib/unsplash.ts
@@ -1,0 +1,22 @@
+import unsplashImagesJson from "@/data/unsplash-images.json";
+
+type UnsplashImage = {
+  url: string;
+  photographer: string;
+  photographerUrl: string;
+  unsplashUrl: string;
+};
+
+function hashSlug(slug: string): number {
+  let hash = 5381;
+  for (let i = 0; i < slug.length; i++) {
+    hash = ((hash << 5) + hash + slug.charCodeAt(i)) >>> 0;
+  }
+  return hash;
+}
+
+export function getUnsplashImageForSlug(slug: string): UnsplashImage | null {
+  const images = unsplashImagesJson as UnsplashImage[];
+  if (images.length === 0) return null;
+  return images[hashSlug(slug) % images.length];
+}


### PR DESCRIPTION
- Add scripts/fetch-unsplash.mjs to pre-fetch 30 tech images from Unsplash API
- Add src/data/unsplash-images.json with pre-fetched image URLs
- Add src/lib/unsplash.ts with deterministic slug-based image selection
- Update ArticleCard, HeroSection, ArticleDetail to show Unsplash images when no coverImage
- Include photographer attribution as required by Unsplash guidelines
- Add fetch-unsplash npm script