### PR TITLE
feat: feed.xml 専用の CloudFront cache behavior (#8)

### DIFF
--- a/infra/lib/blog-stack.ts
+++ b/infra/lib/blog-stack.ts
@@ -228,6 +228,36 @@ function handler(event) {
       }
     );
 
+    // /feed.xml は static export なので Response ヘッダがコード側では効かない。
+    // CDN 側で Cache-Control を返す ResponseHeadersPolicy + 内部 TTL の CachePolicy を作る。
+    // 採用値の根拠: dx-wiki/decisions/why-stale-while-revalidate-86400.md
+    // 注意: dx-wiki/gotchas/stale-while-revalidate-pitfall.md に運用上の落とし穴あり
+    const feedCachePolicy = new cloudfront.CachePolicy(this, "FeedCachePolicy", {
+      cachePolicyName: `${this.stackName}-feed-cache`,
+      defaultTtl: cdk.Duration.hours(1),
+      minTtl: cdk.Duration.minutes(5),
+      maxTtl: cdk.Duration.days(1),
+      enableAcceptEncodingGzip: true,
+      enableAcceptEncodingBrotli: true,
+    });
+    const feedResponseHeadersPolicy = new cloudfront.ResponseHeadersPolicy(
+      this,
+      "FeedResponseHeadersPolicy",
+      {
+        responseHeadersPolicyName: `${this.stackName}-feed-headers`,
+        customHeadersBehavior: {
+          customHeaders: [
+            {
+              header: "Cache-Control",
+              value: "public, max-age=3600, stale-while-revalidate=86400",
+              override: true,
+            },
+            { header: "X-Content-Type-Options", value: "nosniff", override: true },
+          ],
+        },
+      },
+    );
+
     // CloudFront distribution with OAC for both buckets
     // /api/* behavior は API Gateway を origin として追加 (キャッシュ無効化、全 method 許可)
     const distribution = new cloudfront.Distribution(this, "Distribution", {
@@ -244,6 +274,13 @@ function handler(event) {
         ],
       },
       additionalBehaviors: {
+        "/feed.xml": {
+          origin: origins.S3BucketOrigin.withOriginAccessControl(siteBucket),
+          viewerProtocolPolicy:
+            cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+          cachePolicy: feedCachePolicy,
+          responseHeadersPolicy: feedResponseHeadersPolicy,
+        },
         "/media/*": {
           origin: origins.S3BucketOrigin.withOriginAccessControl(mediaBucket),
           viewerProtocolPolicy:

--- a/infra/lib/feed-cache.test.ts
+++ b/infra/lib/feed-cache.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import { App } from "aws-cdk-lib";
+import { Template, Match } from "aws-cdk-lib/assertions";
+import { BlogStack } from "../lib/blog-stack";
+
+describe("feed.xml CloudFront cache behavior (issue#8)", () => {
+  function synth() {
+    const app = new App();
+    const stack = new BlogStack(app, "BlogTest", {
+      env: { account: "123456789012", region: "us-east-1" },
+    });
+    return Template.fromStack(stack);
+  }
+
+  it("Cache-Control ヘッダが Response Headers Policy で設定される", () => {
+    const template = synth();
+    template.hasResourceProperties(
+      "AWS::CloudFront::ResponseHeadersPolicy",
+      Match.objectLike({
+        ResponseHeadersPolicyConfig: Match.objectLike({
+          CustomHeadersConfig: Match.objectLike({
+            Items: Match.arrayWith([
+              Match.objectLike({
+                Header: "Cache-Control",
+                Value: "public, max-age=3600, stale-while-revalidate=86400",
+                Override: true,
+              }),
+            ]),
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("X-Content-Type-Options: nosniff も付与される（security-reviewer 指摘）", () => {
+    synth().hasResourceProperties(
+      "AWS::CloudFront::ResponseHeadersPolicy",
+      Match.objectLike({
+        ResponseHeadersPolicyConfig: Match.objectLike({
+          CustomHeadersConfig: Match.objectLike({
+            Items: Match.arrayWith([
+              Match.objectLike({ Header: "X-Content-Type-Options", Value: "nosniff" }),
+            ]),
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("/feed.xml 専用の CachePolicy が defaultTtl 1h で作られる", () => {
+    synth().hasResourceProperties(
+      "AWS::CloudFront::CachePolicy",
+      Match.objectLike({
+        CachePolicyConfig: Match.objectLike({
+          DefaultTTL: 3600,
+          MinTTL: 300,
+          MaxTTL: 86400,
+        }),
+      }),
+    );
+  });
+});

--- a/infra/vitest.config.ts
+++ b/infra/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["lib/**/*.test.ts"],
+    environment: "node",
+  },
+});


### PR DESCRIPTION
## 関連 issue
Closes #8（PR#5 の architectural follow-up）

## 集合知が誘導した実装
1. **dx-wiki/decisions/why-stale-while-revalidate-86400.md**（山田が前日投入）→ 値が `max-age=3600 + stale-while-revalidate=86400` で確定
2. **dx-wiki/gotchas/stale-while-revalidate-pitfall.md**（同上）→ 緊急 purge 運用が必要と判明
3. **PR#5 の security-reviewer 指摘**（前日）→ `nosniff` も付ける
4. **PR#5 の test-engineer 指摘**（前日）→ `__tests__/` パスは拾われない罠を回避、infra/lib 同階層に配置

## 変更概要
- infra/lib/blog-stack.ts: feed.xml 専用 CachePolicy + ResponseHeadersPolicy 追加
- infra/lib/feed-cache.test.ts: CDK assertions で 3 ケース
- infra/vitest.config.ts: infra 用テスト config 新規

## テスト結果
- ✅ Cache-Control ヘッダの検証
- ✅ nosniff 付与の検証
- ✅ CachePolicy TTL 値の検証

## レビュー観点
- defaultTtl 1h は妥当か
- ResponseHeadersPolicy のヘッダで漏れがないか（CORS, HSTS など追加？）
- stale-while-revalidate の運用ルール（gotchas 参照）は別ドキュメント化したい

## 集合知への複利化
このPR の知見を新パターン `wiki/patterns/static-export-cache-via-cloudfront.md` として登録予定（次回同じ罠を踏まないため）

🤖 集合知駆動の実装デモ